### PR TITLE
Added Editable Tags feature and other enhancements

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -485,6 +485,10 @@ disabled look for disabled choices in the results dropdown
 
 /* multiselect */
 
+.select2-container-multi.select2-dropdown-open {
+    z-index: 9999;
+}
+
 .select2-container-multi .select2-choices {
     height: auto !important;
     height: 1%;


### PR DESCRIPTION
# Constructor

| Parameter | Type | Description |
| --- | --- | --- |
| clearSearchOnClose | boolean | If set to false, the value of search field will not be cleared when select2 loses focus/closes. Default is true. |
| editableTags | boolean | If set to true, tags will be editable when double clicked. Default is false. |
| getDataText | function | This is used only when editableTags parameter is set to true.This function is called from within the callback function for "Double click" tags event. This function returns a string that will be used as the value for the search field.if this function returned a falsy value, the tag will not be editable. |
# Events
# select2-before-update

Fired before tags are updated/removed from DOM.
https://guides.github.com/features/mastering-markdown/
