### PR TITLE
Changing mask 'click' event to a 'mousedown' event

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1410,7 +1410,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 mask.attr("id","select2-drop-mask").attr("class","select2-drop-mask");
                 mask.hide();
                 mask.appendTo(this.body);
-                mask.on("click", function (e) {
+                mask.on("mousedown", function (e) {
                     // Prevent IE from generating a click event on the body
                     reinsertElement(mask);
 


### PR DESCRIPTION
Because the event related to closing a select2 dropdown was on click, it will occur after all events that linked to mousedown first. Because the closing of the dropdown stops propagation of the event, it likely should not have bearing on event handlers related to half-clicking either.

This became an issue when a select2 was added to a bootstrap popover. It closes on a document mousedown event, so a click on the select2 dropdown mask would first close the popover no matter where the click was located and then close the dropdown immediately after. 